### PR TITLE
Issue/24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,16 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'org.springframework.boot' version '2.7.1'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id 'jacoco'
+	// querydsl 플러그인 추가
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.project'
@@ -47,6 +55,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.1.RELEASE'
+
+	// querydsl 디펜던시 추가
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 
 }
 
@@ -105,4 +117,32 @@ task testCoverage(type: Test) {
 
 	tasks['jacocoTestReport'].mustRunAfter(tasks['test'])
 	tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
+}
+
+// querydsl 사용할 경로 지정합니다. 현재 지정한 부분은 .gitignore에 포함되므로 git에 올라가지 않습니다.
+def querydslDir = "$buildDir/generated/'querydsl'"
+
+// JPA 사용여부 및 사용 경로 설정
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+
+// build시 사용할 sourceSet 추가 설정
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+
+// querydsl 컴파일 시 사용할 옵션 설정
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
+}
+
+// querydsl이 compileClassPath를 상속하도록 설정
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/com/project/Project/Util/QueryDslUtil.java
+++ b/src/main/java/com/project/Project/Util/QueryDslUtil.java
@@ -1,0 +1,35 @@
+package com.project.Project.Util;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+public class QueryDslUtil {
+
+    public static OrderSpecifier<?> getSortedColumn(Order order, Path<?> parent, String fieldName){
+        Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
+        return new OrderSpecifier(order, fieldPath);
+    }
+
+    public static <T> Slice<T> toSlice(List<T> contents, Pageable pageable) {
+
+        boolean hasNext = isContentSizeGreaterThanPageSize(contents, pageable);
+        return new SliceImpl<>(hasNext ? subListLastContent(contents, pageable) : contents, pageable, hasNext);
+    }
+
+    // 다음 페이지 있는지 확인
+    private static <T> boolean isContentSizeGreaterThanPageSize(List<T> content, Pageable pageable) {
+        return pageable.isPaged() && content.size() > pageable.getPageSize();
+    }
+
+    // 데이터 1개 빼고 반환
+    private static <T> List<T> subListLastContent(List<T> content, Pageable pageable) {
+        return content.subList(0, pageable.getPageSize());
+    }
+}

--- a/src/main/java/com/project/Project/config/QuerydslConfig.java
+++ b/src/main/java/com/project/Project/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.project.Project.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em){
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/project/Project/controller/building/BuildingRestController.java
+++ b/src/main/java/com/project/Project/controller/building/BuildingRestController.java
@@ -99,9 +99,11 @@ public class BuildingRestController {
     return: 건물 정보
      */
     @GetMapping("/search")
-    public List<BuildingResponseDto.BuildingResponse> searchBuilding(@RequestParam("params") String params, @RequestBody CursorDto cursorDto) {
-        List<Building> buildingList = this.buildingService.getBuildingBySearch(params, cursorDto.getCursorId(),PageRequest.of(0, cursorDto.getSize()));
-        return buildingList.stream().parallel()
-                .map(BuildingSerializer::toBuildingResponse).collect(Collectors.toList());
+    public ResponseEntity<Slice<BuildingResponseDto.BuildingListResponse>> searchBuilding(@RequestParam("params") String params, @RequestBody CursorDto cursorDto) {
+        Pageable pageable = PageRequest.of(0, cursorDto.getSize());
+//        List<Building> buildingList = this.buildingService.getBuildingBySearch(params, cursorDto.getCursorId(),PageRequest.of(0, cursorDto.getSize()));
+        List<Building> buildingList = this.buildingService.getBuildingsBySearch(params, cursorDto.getCursorId(), pageable);
+        List<BuildingResponseDto.BuildingListResponse> buildingListResponse = buildingList.stream().map((building) -> BuildingSerializer.toBuildingListResponse(building)).collect(Collectors.toList());
+        return ResponseEntity.ok(QueryDslUtil.toSlice(buildingListResponse,pageable));
     }
 }

--- a/src/main/java/com/project/Project/controller/building/BuildingRestController.java
+++ b/src/main/java/com/project/Project/controller/building/BuildingRestController.java
@@ -1,5 +1,6 @@
 package com.project.Project.controller.building;
 
+import com.project.Project.Util.QueryDslUtil;
 import com.project.Project.controller.CursorDto;
 import com.project.Project.controller.building.dto.BuildingResponseDto;
 import com.project.Project.domain.building.Building;
@@ -14,6 +15,9 @@ import com.project.Project.service.ReviewService;
 import com.project.Project.validator.ExistBuilding;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/project/Project/domain/building/Building.java
+++ b/src/main/java/com/project/Project/domain/building/Building.java
@@ -5,6 +5,7 @@ import com.project.Project.controller.room.dto.RoomResponseDto;
 import com.project.Project.domain.BaseEntity;
 import com.project.Project.domain.enums.ReviewCategoryEnum;
 import com.project.Project.domain.interaction.Favorite;
+import com.project.Project.domain.review.ReviewSummary;
 import com.project.Project.domain.room.Room;
 import com.project.Project.domain.embedded.Address;
 import com.project.Project.domain.embedded.Coordinate;
@@ -68,6 +69,9 @@ public class Building extends BaseEntity {
     @OneToMany(mappedBy = "building")
     @Builder.Default
     private List<BuildingToReviewCategory> buildingToReviewCategoryList = new ArrayList<>();
+
+    @OneToOne(mappedBy = "building")
+    private BuildingSummary buildingSummary;
 
     // TODO : 이미지 업로드 방법에 따라 추후 필드 추가. ex) S3업로드 or ec2 서버내에 업로드 등
 

--- a/src/main/java/com/project/Project/domain/building/Building.java
+++ b/src/main/java/com/project/Project/domain/building/Building.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@Getter @NoArgsConstructor @AllArgsConstructor @Builder
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 @SQLDelete(sql = "UPDATE building SET deleted = true WHERE id=?")
 @Where(clause = "deleted=false")
 @Entity

--- a/src/main/java/com/project/Project/domain/building/BuildingSummary.java
+++ b/src/main/java/com/project/Project/domain/building/BuildingSummary.java
@@ -1,0 +1,35 @@
+package com.project.Project.domain.building;
+
+import com.project.Project.domain.review.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@SQLDelete(sql = "UPDATE building_summary SET deleted = true WHERE id=?")
+@Where(clause = "deleted=false")
+@Entity
+public class BuildingSummary {
+    @Id @GeneratedValue
+    private Long id;
+
+    @OneToOne()
+    @JoinColumn(name = "building_id")
+    private Building building;
+
+    private Double avgScore;
+
+    private Long reviewCnt;
+
+    public void setBuilding(Building building) {
+        this.building = building;
+    }
+}

--- a/src/main/java/com/project/Project/repository/BuildingToReviewCategoryRepository.java
+++ b/src/main/java/com/project/Project/repository/BuildingToReviewCategoryRepository.java
@@ -1,7 +1,13 @@
 package com.project.Project.repository;
 
+import com.project.Project.domain.building.Building;
 import com.project.Project.domain.building.BuildingToReviewCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface BuildingToReviewCategoryRepository extends JpaRepository<BuildingToReviewCategory, Long> {
+    @Query("select distinct brc from BuildingToReviewCategory brc join fetch brc.reviewCategory rc where brc.building = :id ")
+    List<BuildingToReviewCategory> findBuildingToReviewCategoriesByBuilding_Id(Long id);
 }

--- a/src/main/java/com/project/Project/repository/building/BuildingCustomRepository.java
+++ b/src/main/java/com/project/Project/repository/building/BuildingCustomRepository.java
@@ -3,10 +3,13 @@ package com.project.Project.repository.building;
 import com.project.Project.domain.building.Building;
 import com.querydsl.jpa.impl.JPAQuery;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.function.Function;
 
 public interface BuildingCustomRepository {
-    Function<String,JPAQuery<Building>> searchBuildingsQuery ();
+    Function<String,JPAQuery<Building>> searchBuildingsQuery ( Long cursorId, Pageable pageable);
+
+    List<Building> searchBuildings(String params, Long cursorId, Pageable pageable);
 }

--- a/src/main/java/com/project/Project/repository/building/BuildingCustomRepository.java
+++ b/src/main/java/com/project/Project/repository/building/BuildingCustomRepository.java
@@ -1,0 +1,12 @@
+package com.project.Project.repository.building;
+
+import com.project.Project.domain.building.Building;
+import com.querydsl.jpa.impl.JPAQuery;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.function.Function;
+
+public interface BuildingCustomRepository {
+    Function<String,JPAQuery<Building>> searchBuildingsQuery ();
+}

--- a/src/main/java/com/project/Project/repository/building/BuildingRepository.java
+++ b/src/main/java/com/project/Project/repository/building/BuildingRepository.java
@@ -1,6 +1,7 @@
-package com.project.Project.repository;
+package com.project.Project.repository.building;
 
 import com.project.Project.domain.building.Building;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/project/Project/repository/building/BuildingRepositoryImpl.java
+++ b/src/main/java/com/project/Project/repository/building/BuildingRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.project.Project.repository.building;
+
+import com.project.Project.domain.building.Building;
+import com.project.Project.domain.building.BuildingToReviewCategory;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static com.project.Project.domain.building.QBuilding.building;
+import static com.project.Project.domain.building.QBuildingToReviewCategory.buildingToReviewCategory;
+
+@Repository
+@RequiredArgsConstructor
+public class BuildingRepositoryImpl implements BuildingCustomRepository {
+    private final JPAQueryFactory factory;
+
+
+    public Function<String,JPAQuery<Building>> searchBuildingsQuery() {
+        return (params) -> factory.selectFrom(building)
+                .innerJoin(building.buildingToReviewCategoryList, buildingToReviewCategory).fetchJoin()
+                .where(buildingSearchPredicate(params));
+    }
+
+    private BooleanBuilder notDeletedCondition() {
+        return new BooleanBuilder()
+                .and(building.deleted.ne(true));
+    }
+
+    private BooleanBuilder buildingSearchPredicate(String params) {
+        return new BooleanBuilder()
+                .orAllOf(building.address.metropolitanGovernment.contains(params),
+                        building.address.basicLocalGovernment.contains(params),
+                        building.address.siGunGu.contains(params),
+                        building.address.eupMyeon.contains(params),
+                        building.address.roadName.contains(params),
+                        building.address.buildingNumber.contains(params),
+                        building.buildingName.contains(params))
+                .and(notDeletedCondition());
+    }
+
+    public Function<JPAQuery<Building>,JPAQuery<Building>> sortBy(Long cursorId, Pageable pageable) {
+
+        return (query) -> query.orderBy(building.id.desc())
+                .offset(cursorId)
+                .limit(pageable.getPageSize());
+    }
+}

--- a/src/main/java/com/project/Project/repository/building/BuildingRepositoryImpl.java
+++ b/src/main/java/com/project/Project/repository/building/BuildingRepositoryImpl.java
@@ -33,6 +33,12 @@ import static org.springframework.util.ObjectUtils.isEmpty;
 public class BuildingRepositoryImpl implements BuildingCustomRepository {
     private final JPAQueryFactory factory;
 
+    public List<Building> searchBuildings(String params, Long cursorId, Pageable pageable) {
+        List<Building> results = searchBuildingsQuery(cursorId,pageable).andThen(customOrderBy(pageable)).apply(params)
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+        return results;
+    }
 
     public Function<String, JPAQuery<Building>> searchBuildingsQuery(Long cursorId, Pageable pageable) {
         return (params) -> factory.selectFrom(building)

--- a/src/main/java/com/project/Project/service/BuildingService.java
+++ b/src/main/java/com/project/Project/service/BuildingService.java
@@ -3,6 +3,7 @@ package com.project.Project.service;
 import com.project.Project.domain.building.Building;
 import com.project.Project.repository.projection.building.OnlyBuildingIdAndCoord;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,7 +11,7 @@ import java.util.Optional;
 public interface BuildingService {
     List<Building> getBuildingListByBuildingIds(List<Long> buildingIds, Long cursorId, Pageable page);
     Building getBuildingByBuildingId(Long buildingId);
-    List<Building> getBuildingBySearch(String params, Long cursorId, Pageable page);
+    List<Building> getBuildingsBySearch(String params, Long cursorId, Pageable page);
     Optional<Building> findByAddress(String address);
     List<OnlyBuildingIdAndCoord> getAllBuildingsIdAndCoord();
     Building createBuilding(String address);

--- a/src/main/java/com/project/Project/service/impl/BuildingServiceImpl.java
+++ b/src/main/java/com/project/Project/service/impl/BuildingServiceImpl.java
@@ -1,12 +1,15 @@
 package com.project.Project.service.impl;
 
 import com.project.Project.domain.building.Building;
-import com.project.Project.repository.BuildingRepository;
+import com.project.Project.repository.building.BuildingCustomRepository;
+import com.project.Project.repository.building.BuildingRepository;
 import com.project.Project.repository.ReviewRepository;
 import com.project.Project.repository.RoomRepository;
 import com.project.Project.repository.projection.building.OnlyBuildingIdAndCoord;
 import com.project.Project.service.BuildingService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,6 +19,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class BuildingServiceImpl implements BuildingService {
     private final BuildingRepository buildingRepository;
+    private final BuildingCustomRepository buildingCustomRepo;
     private final RoomRepository roomRepository;
     private final ReviewRepository reviewRepository;
 
@@ -35,8 +39,9 @@ public class BuildingServiceImpl implements BuildingService {
     }
 
     @Override
-    public List<Building> getBuildingBySearch(String params) {
-        return buildingRepository.searchBuildings(params);
+    public List<Building> getBuildingsBySearch(String params, Long cursorId, Pageable page) {
+//        return buildingRepository.searchBuildings(params);
+       return  buildingCustomRepo.searchBuildings(params,cursorId,page);
     }
 
     @Override

--- a/src/main/java/com/project/Project/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/com/project/Project/service/impl/ReviewServiceImpl.java
@@ -4,7 +4,7 @@ import com.project.Project.domain.building.Building;
 import com.project.Project.domain.review.Review;
 import com.project.Project.domain.review.ReviewImage;
 import com.project.Project.domain.room.Room;
-import com.project.Project.repository.BuildingRepository;
+import com.project.Project.repository.building.BuildingRepository;
 import com.project.Project.repository.ReviewRepository;
 import com.project.Project.repository.RoomRepository;
 import com.project.Project.service.ReviewService;
@@ -73,7 +73,7 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Transactional
     public Long deleteById(Long reviewId) {
-        List<ReviewImage> reviewImageList = reviewRepository.findById(reviewId).get().getReviewForm().getReviewImageList();
+        List<ReviewImage> reviewImageList = reviewRepository.findById(reviewId).get().getReviewImageList();
         for(ReviewImage reviewImage : reviewImageList) {
             fileProcessService.deleteImage(reviewImage.getUrl());
         }

--- a/src/main/java/com/project/Project/validator/BuildingExistValidator.java
+++ b/src/main/java/com/project/Project/validator/BuildingExistValidator.java
@@ -1,6 +1,6 @@
 package com.project.Project.validator;
 
-import com.project.Project.repository.BuildingRepository;
+import com.project.Project.repository.building.BuildingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/test/java/com/project/Project/controller/validation/BuildingRequestValidationTest.java
+++ b/src/test/java/com/project/Project/controller/validation/BuildingRequestValidationTest.java
@@ -7,7 +7,7 @@ import com.project.Project.controller.building.BuildingRestController;
 import com.project.Project.controller.building.dto.BuildingRequestDto;
 import com.project.Project.domain.building.Building;
 import com.project.Project.domain.embedded.Address;
-import com.project.Project.repository.BuildingRepository;
+import com.project.Project.repository.building.BuildingRepository;
 import com.project.Project.validator.BuildingExistValidator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/project/Project/controller/validation/ReviewRequestValidationTest.java
+++ b/src/test/java/com/project/Project/controller/validation/ReviewRequestValidationTest.java
@@ -4,7 +4,7 @@
 //import com.project.Project.WithMockCustomOAuth2Account;
 //import com.project.Project.config.auth.SecurityConfig;
 //import com.project.Project.controller.review.controller.ReviewRestController;
-//import com.project.Project.repository.BuildingRepository;
+//import com.project.Project.repository.building.BuildingRepository;
 //import com.project.Project.repository.ReviewRepository;
 //import com.project.Project.repository.RoomRepository;
 //import com.project.Project.service.BuildingService;

--- a/src/test/java/com/project/Project/repository/BuildingRepositoryTest.java
+++ b/src/test/java/com/project/Project/repository/BuildingRepositoryTest.java
@@ -4,6 +4,7 @@ import com.project.Project.domain.building.Building;
 import com.project.Project.domain.embedded.Address;
 import com.project.Project.domain.embedded.Coordinate;
 import com.project.Project.domain.room.Room;
+import com.project.Project.repository.building.BuildingRepository;
 import com.project.Project.repository.projection.building.OnlyBuildingIdAndCoord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
/building/search 재구현

- cursor-based pagination을 적용
- 건물 list 보여주는 페이지에 보면 정렬기준이 있고 이를 확장 가능하게 구현하기 위해 Querydsl 사용
- Querydsl을 적용한 customRepo에서 쿼리문을 조합해서 쓸 수 있도록 함수에서 lambda를 return 하도록 구현